### PR TITLE
add shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
       imports = [
         ./dev.nix
         ./packages
+        ./shell.nix
       ];
 
       perSystem =

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{
+  perSystem =
+    {
+      lib,
+      pkgs,
+      config,
+      ...
+    }:
+    {
+      devShells.default = pkgs.mkShell {
+
+        # Add all the packages declared in ./packages/default.nix to the shell environment.
+        buildInputs = lib.attrValues config.packages;
+      };
+    };
+}


### PR DESCRIPTION
Add a `devShell` output to the flake.

Can be activated as follows:
```
nix develop
```